### PR TITLE
スポット検索バグ修正

### DIFF
--- a/src/b-map/app/Http/Controllers/SpotSearchController.php
+++ b/src/b-map/app/Http/Controllers/SpotSearchController.php
@@ -28,12 +28,14 @@ class SpotSearchController extends Controller
     
             $spots->withPath("/api/search/?keyword={$keyword}");
 
-            $spots->map(function ($spot) {
-                $spot->isFavorite = $spot->favorites->contains(function ($favorite) {
-                    return $favorite->user_id === auth()->user()->id;
+            if (auth()->user()) {
+                $spots->map(function ($spot) {
+                    $spot->isFavorite = $spot->favorites->contains(function ($favorite) {
+                        return $favorite->user_id === auth()->user()->id;
+                    });
+                    return $spot;
                 });
-                return $spot;
-            });
+            }
             
         return response()->json($spots);
     }


### PR DESCRIPTION
### Why
- 未ログイン時のみスポット検索時のエラーが発生するためその修正
## 実装内容
 - SpotSearchController.phpのロジックを変更

## Ref
- #50 
## Check
- [x] インデントのズレ
- [x] 不要なスペース
- [x] テスト用cosole.log消す
- [x] 不要な改行
