### PR TITLE
create ResetPasswordNotification

### DIFF
--- a/src/b-map/app/Models/User.php
+++ b/src/b-map/app/Models/User.php
@@ -11,6 +11,7 @@ use App\Models\SocialAccount;
 use App\Models\Spot;
 use App\Models\Review;
 use App\Models\Favorite;
+use App\Notifications\ResetPasswordNotification;
 
 class User extends Authenticatable
 {
@@ -61,5 +62,11 @@ class User extends Authenticatable
 
     public function favorites() {
         return $this->hasMany(Favorite::class);
+    }
+
+    public function sendPasswordResetNotification($token)
+    {
+        $url = url("reset-password/${token}");
+        $this->notify(new ResetPasswordNotification($url));
     }
 }

--- a/src/b-map/app/Notifications/ResetPasswordNotification.php
+++ b/src/b-map/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Lang;
+
+class ResetPasswordNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject(Lang::get('パスワードリセットの通知'))
+            ->greeting('こんにちは' . $notifiable->name . 'さん')
+            ->line(Lang::get('あなたのアカウントからパスワードリセットのリクエストがあったため、このメールを送信しています。パスワードをリセットする場合は下のボタンをクリックしてください。'))
+            ->action(Lang::get('パスワードをリセット'), $this->url)
+            ->line(Lang::get('このパスワードリセットリンクの有効期限は :count 分です', ['count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]))
+            ->line(Lang::get('もし身に覚えがない場合はこのメールは無視して下さい。'));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
### What
通知クラスのオーバーライド
## 実装内容
 - UserモデルにsendPasswordResetNotificationメソッド定義
 - ResetPasswordNotification.phpのコンストラクタとtoMailメソッドの中身をカスタマイズ

## Ref
- 関連PR/issueへの参照リンク
## Check
- [x] インデントのズレ
- [x] 不要なスペース
- [x] テスト用cosole.log消す
- [x] 不要な改行
