### PR TITLE
fixed AppServiceProvider.php

### DIFF
--- a/src/b-map/app/Providers/AppServiceProvider.php
+++ b/src/b-map/app/Providers/AppServiceProvider.php
@@ -26,6 +26,7 @@ class AppServiceProvider extends ServiceProvider
         // 本番環境(Heroku)でhttpsを強制する
         if (\App::environment('production')) {
             \URL::forceScheme('https');
+            $this->app['request']->server->set('HTTPS','on');
         }
     }
 }


### PR DESCRIPTION
# Why
- ページネーション機能で、2ページ目以降のURLがhttpsでリクエストされないためエラーが起きた
## 実装内容
 - AppServiceProvider.phpのbootメソッド内を編集

## Ref
- 関連PR/issueへの参照リンク
## Check
- [ ] インデントのズレ
- [ ] 不要なスペース
- [ ] テスト用cosole.log消す
- [ ] 不要な改行
